### PR TITLE
Fix urls by adding trailing slash

### DIFF
--- a/property/urls.py
+++ b/property/urls.py
@@ -7,11 +7,11 @@ urlpatterns = [
         PropertyList.as_view()
     ),
     path(
-        'property/create',
+        'property/create/',
         PropertyCreate.as_view()
     ),
     path(
-        'property/<int:pk>',
+        'property/<int:pk>/',
         PropertyDetail.as_view()
     ),
 ]


### PR DESCRIPTION
- API for property data will not accept network requests from front-end. 
- As part of a solution, I checked the urls.py file and realised the "/" was not present at the end of the string, which may be affecting the API endpoint.