### PR TITLE
User App: Remove custom user detail serializer

### DIFF
--- a/property_andalucia_api/serializers.py
+++ b/property_andalucia_api/serializers.py
@@ -9,5 +9,6 @@ class CurrentUserSerializer(UserDetailsSerializer):
     class Meta(UserDetailsSerializer.Meta):
         fields = UserDetailsSerializer.Meta.fields + (
             'profile_id',
-            'profile_image'
+            'profile_image',
+            'seller_status',
         )

--- a/property_andalucia_api/settings.py
+++ b/property_andalucia_api/settings.py
@@ -55,9 +55,6 @@ REST_AUTH_SERIALIZERS = {
     'USER_DETAILS_SERIALIZER': (
         'property_andalucia_api.serializers.CurrentUserSerializer'
     ),
-    'USER_DETAILS_SERIALIZER': (
-        'users.serializers.SellerStatusSerializerDetail'
-    ),
 }
 
 REST_AUTH_REGISTER_SERIALIZERS = {

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -22,19 +22,3 @@ class SellerStatusSerializer(RegisterSerializer):
         )
         user.save()
         return user
-
-
-class SellerStatusSerializerDetail(serializers.ModelSerializer):
-
-    class Meta:
-        model = UpdatedUser
-        fields = (
-            'pk',
-            'username',
-            'email',
-            'seller_status',
-            'is_staff',
-            'is_active',
-            'is_superuser',
-            'date_joined',
-        )


### PR DESCRIPTION
- Remove previously made customer user detail serializer as it conflicted with the already made custom serializer found in the core project file.
- Add the seller_status there instead, which solved the problem.